### PR TITLE
fix typo in OI

### DIFF
--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -120,7 +120,7 @@ public class OI extends Procedure {
 
 			// first, check if the boxop is making a cone or cube selection
 			if (boxopGamepad.getPOV() == InputConstants.POV_UP) {
-				new GoForCubes().run(context);
+				new GoForCones().run(context);
 			} else if (boxopGamepad.getPOV() == InputConstants.POV_DOWN) {
 				new GoForCubes().run(context);
 			}


### PR DESCRIPTION
fix typo in OI.  POV UP should select cones not cubes
