### PR TITLE
Sequenced procedures for moving the elevator and wrist

### DIFF
--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -160,16 +160,16 @@ public class OI extends Procedure {
 					case NONE:
 						break;
 					case LOW_NODE:
-						new ExtendWristvatorToLow().run(context);
+						context.startAsync(new ExtendWristvatorToLow());
 						break;
 					case MID_NODE:
-						new ExtendWristvatorToMid().run(context);
+						context.startAsync(new ExtendWristvatorToMid());
 						break;
 					case HIGH_NODE:
-						new ExtendWristvatorToHigh().run(context);
+						context.startAsync(new ExtendWristvatorToHigh());
 						break;
 					case HUMAN_PLAYER:
-						new ExtendWristvatorToHuman().run(context);
+						context.startAsync(new ExtendWristvatorToHuman(Robot.intake.getGamePieceType()));
 						break;
 					default:
 					// warn, ignore
@@ -177,7 +177,7 @@ public class OI extends Procedure {
 					break;
 				}
 			} else if (boxopGamepad.getButtonReleased(InputConstants.BUTTON_EXTEND_WRISTVATOR)) {
-				new RetractWristvator().run(context);
+				context.startAsync(new RetractWristvator());
 			}
 
 			// look for manual nudges

--- a/src/main/java/com/team766/robot/mechanisms/Elevator.java
+++ b/src/main/java/com/team766/robot/mechanisms/Elevator.java
@@ -34,19 +34,21 @@ public class Elevator extends Mechanism {
 		/** Elevator is fully extended. */
 		EXTENDED(40);
 
-		private final int height;
+		private final double height;
 
-		Position(int position) {
+		Position(double position) {
 			this.height = position;
 		}
 
-		private int getHeight() {
+		private double getHeight() {
 			return height;
 		}
 	}
 
 	private static final double NUDGE_INCREMENT = 5.0;
 	private static final double NUDGE_DAMPENER = 0.25;
+
+	private static final double NEAR_THRESHOLD = 2.0;
 
 	private final CANSparkMax leftMotor;
 	private final CANSparkMax rightMotor;
@@ -102,6 +104,14 @@ public class Elevator extends Mechanism {
 	 */
 	public double getHeight() {
 		return EncoderUtils.elevatorRotationsToHeight(leftMotor.getEncoder().getPosition());
+	}
+
+	public boolean isNearTo(Position position) {
+		return isNearTo(position.getHeight());
+	}
+
+	public boolean isNearTo(double position) {
+		return Math.abs(position - getHeight()) < NEAR_THRESHOLD;
 	}
 
 	public void nudgeNoPID(double value) {

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -67,6 +67,8 @@ public class Intake extends Mechanism {
 	 * Sets the type of game piece type the Intake is preparing to hold or is holding.
 	 */
 	public void setGamePieceType(GamePieceType type) {
+		checkContextOwnership();
+
 		this.gamePieceType = type;
 	}
 

--- a/src/main/java/com/team766/robot/mechanisms/Wrist.java
+++ b/src/main/java/com/team766/robot/mechanisms/Wrist.java
@@ -55,6 +55,8 @@ public class Wrist extends Mechanism {
 	private static final double NUDGE_INCREMENT = 5.0;
 	private static final double NUDGE_DAMPENER = 0.15;
 
+	private static final double NEAR_THRESHOLD = 5.0;
+
 	private final CANSparkMax motor;
 	private final SparkMaxPIDController pidController;
 	private final ValueProvider<Double> pGain;
@@ -97,6 +99,14 @@ public class Wrist extends Mechanism {
 	 */
 	public double getAngle() {
 		return EncoderUtils.wristRotationsToDegrees(motor.getEncoder().getPosition());
+	}
+
+	public boolean isNearTo(Position position) {
+		return isNearTo(position.getAngle());
+	}
+
+	public boolean isNearTo(double angle) {
+		return Math.abs(angle - getAngle()) < NEAR_THRESHOLD;
 	}
 
 	public void nudgeNoPID(double value) {

--- a/src/main/java/com/team766/robot/procedures/ExtendWristvatorToHigh.java
+++ b/src/main/java/com/team766/robot/procedures/ExtendWristvatorToHigh.java
@@ -1,19 +1,11 @@
 package com.team766.robot.procedures;
 
-import com.team766.framework.Context;
-import com.team766.framework.Procedure;
-import com.team766.robot.Robot;
 import com.team766.robot.mechanisms.Elevator;
 import com.team766.robot.mechanisms.Wrist;
 
-public class ExtendWristvatorToHigh extends Procedure {
+public class ExtendWristvatorToHigh extends MoveWristvator {
 
-	@Override
-	public void run(Context context) {
-		context.takeOwnership(Robot.wrist);
-		context.takeOwnership(Robot.elevator);
-
-		Robot.elevator.moveTo(Elevator.Position.HIGH);
-		Robot.wrist.rotate(Wrist.Position.HIGH_NODE);
+	public ExtendWristvatorToHigh() {
+		super(Elevator.Position.HIGH, Wrist.Position.HIGH_NODE);
 	}
 }

--- a/src/main/java/com/team766/robot/procedures/ExtendWristvatorToHuman.java
+++ b/src/main/java/com/team766/robot/procedures/ExtendWristvatorToHuman.java
@@ -1,26 +1,15 @@
 package com.team766.robot.procedures;
 
-import com.team766.framework.Context;
-import com.team766.framework.Procedure;
-import com.team766.robot.Robot;
 import com.team766.robot.mechanisms.Elevator;
 import com.team766.robot.mechanisms.Wrist;
 import com.team766.robot.mechanisms.Intake.GamePieceType;
 
-public class ExtendWristvatorToHuman extends Procedure {
+public class ExtendWristvatorToHuman extends MoveWristvator {
 
-	@Override
-	public void run(Context context) {
-		context.takeOwnership(Robot.intake);
-		context.takeOwnership(Robot.wrist);
-		context.takeOwnership(Robot.elevator);
-
-		if (Robot.intake.getGamePieceType() == GamePieceType.CONE) {
-			Robot.elevator.moveTo(Elevator.Position.HUMAN_CONES);
-			Robot.wrist.rotate(Wrist.Position.LEVEL);
-		} else {
-			Robot.elevator.moveTo(Elevator.Position.HUMAN_CUBES);
-			Robot.wrist.rotate(Wrist.Position.LEVEL);
-		}
+	public ExtendWristvatorToHuman(GamePieceType gamePieceType) {
+		super(gamePieceType == GamePieceType.CONE
+				? Elevator.Position.HUMAN_CONES
+				: Elevator.Position.HUMAN_CUBES,
+			Wrist.Position.LEVEL);
 	}
 }

--- a/src/main/java/com/team766/robot/procedures/ExtendWristvatorToLow.java
+++ b/src/main/java/com/team766/robot/procedures/ExtendWristvatorToLow.java
@@ -1,19 +1,11 @@
 package com.team766.robot.procedures;
 
-import com.team766.framework.Context;
-import com.team766.framework.Procedure;
-import com.team766.robot.Robot;
 import com.team766.robot.mechanisms.Elevator;
 import com.team766.robot.mechanisms.Wrist;
 
-public class ExtendWristvatorToLow extends Procedure {
+public class ExtendWristvatorToLow extends MoveWristvator {
 
-	@Override
-	public void run(Context context) {
-		context.takeOwnership(Robot.wrist);
-		context.takeOwnership(Robot.elevator);
-
-		Robot.elevator.moveTo(Elevator.Position.LOW);
-		Robot.wrist.rotate(Wrist.Position.LEVEL);
+	public ExtendWristvatorToLow() {
+		super(Elevator.Position.LOW, Wrist.Position.LEVEL);
 	}
 }

--- a/src/main/java/com/team766/robot/procedures/ExtendWristvatorToMid.java
+++ b/src/main/java/com/team766/robot/procedures/ExtendWristvatorToMid.java
@@ -1,19 +1,11 @@
 package com.team766.robot.procedures;
 
-import com.team766.framework.Context;
-import com.team766.framework.Procedure;
-import com.team766.robot.Robot;
 import com.team766.robot.mechanisms.Elevator;
 import com.team766.robot.mechanisms.Wrist;
 
-public class ExtendWristvatorToMid extends Procedure {
+public class ExtendWristvatorToMid extends MoveWristvator {
 
-	@Override
-	public void run(Context context) {
-		context.takeOwnership(Robot.wrist);
-		context.takeOwnership(Robot.elevator);
-
-		Robot.elevator.moveTo(Elevator.Position.MID);
-		Robot.wrist.rotate(Wrist.Position.MID_NODE);
+	public ExtendWristvatorToMid() {
+		super(Elevator.Position.MID, Wrist.Position.MID_NODE);
 	}
 }

--- a/src/main/java/com/team766/robot/procedures/MoveWristvator.java
+++ b/src/main/java/com/team766/robot/procedures/MoveWristvator.java
@@ -1,0 +1,36 @@
+package com.team766.robot.procedures;
+
+import com.team766.framework.Context;
+import com.team766.framework.Procedure;
+import com.team766.robot.Robot;
+import com.team766.robot.mechanisms.Elevator;
+import com.team766.robot.mechanisms.Wrist;
+
+public class MoveWristvator extends Procedure {
+	private final Elevator.Position elevatorSetpoint;
+	private final Wrist.Position wristSetpoint;
+
+	public MoveWristvator(Elevator.Position elevatorSetpoint_, Wrist.Position wristSetpoint_) {
+		this.elevatorSetpoint = elevatorSetpoint_;
+		this.wristSetpoint = wristSetpoint_;
+	}
+
+	@Override
+	public final void run(Context context) {
+		context.takeOwnership(Robot.wrist);
+		context.takeOwnership(Robot.elevator);
+
+		// Always retract the wrist before moving the elevator.
+		// It might already be retracted, so it's possible that this step finishes instantaneously.
+		Robot.wrist.rotate(Wrist.Position.RETRACTED);
+		context.waitFor(() -> Robot.wrist.isNearTo(Wrist.Position.RETRACTED));
+
+		// Move the elevator. Wait until it gets near the target position.
+		Robot.elevator.moveTo(elevatorSetpoint);
+		context.waitFor(() -> Robot.elevator.isNearTo(elevatorSetpoint));
+
+		// Lastly, move the wrist.
+		Robot.wrist.rotate(wristSetpoint);
+		context.waitFor(() -> Robot.wrist.isNearTo(wristSetpoint));
+	}
+}

--- a/src/main/java/com/team766/robot/procedures/RetractWristvator.java
+++ b/src/main/java/com/team766/robot/procedures/RetractWristvator.java
@@ -1,19 +1,11 @@
 package com.team766.robot.procedures;
 
-import com.team766.framework.Context;
-import com.team766.framework.Procedure;
-import com.team766.robot.Robot;
 import com.team766.robot.mechanisms.Elevator;
 import com.team766.robot.mechanisms.Wrist;
 
-public class RetractWristvator extends Procedure {
+public class RetractWristvator extends MoveWristvator {
 
-	@Override
-	public void run(Context context) {
-		context.takeOwnership(Robot.wrist);
-		context.takeOwnership(Robot.elevator);
-
-		Robot.elevator.moveTo(Elevator.Position.RETRACTED);
-		Robot.wrist.rotate(Wrist.Position.RETRACTED);
+	public RetractWristvator() {
+		super(Elevator.Position.RETRACTED, Wrist.Position.RETRACTED);
 	}
 }


### PR DESCRIPTION
## Description

Use `context.waitFor` to ensure that the wrist is stowed while moving the elevator.

Use a shared implementation for all of the Extend/Retract-Wristvator procedures.

## How Has This Been Tested?

No testing yet. Will test on Gatorade tonight.
