### PR TITLE
Refactor swerve code to use new SwerveModule class

### DIFF
--- a/src/main/java/com/team766/robot/mechanisms/Drive.java
+++ b/src/main/java/com/team766/robot/mechanisms/Drive.java
@@ -1,155 +1,192 @@
 package com.team766.robot.mechanisms;
 
+import static com.team766.robot.constants.ConfigConstants.*;
+
 import com.ctre.phoenix.sensors.CANCoder;
 import com.team766.framework.Mechanism;
 import com.team766.hal.MotorController;
 import com.team766.hal.RobotProvider;
 import com.team766.logging.Category;
-import static com.team766.robot.constants.ConfigConstants.*;
-import com.team766.robot.constants.SwerveDriveConstants;
-import com.team766.robot.constants.OdometryInputConstants;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
 import com.team766.odometry.Odometry;
 import com.team766.odometry.Point;
 import com.team766.odometry.PointDir;
+import com.team766.robot.constants.OdometryInputConstants;
+import com.team766.robot.constants.SwerveDriveConstants;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
 
 public class Drive extends Mechanism {
 
-	// SwerveModules
-	private final SwerveModule swerveFR;
-	private final SwerveModule swerveFL;
-	private final SwerveModule swerveBR;
-	private final SwerveModule swerveBL;
+    // SwerveModules
+    private final SwerveModule swerveFR;
+    private final SwerveModule swerveFL;
+    private final SwerveModule swerveBR;
+    private final SwerveModule swerveBL;
 
-	// TODO: rework odometry so it doesn't have to go through drive
+    // TODO: rework odometry so it doesn't have to go through drive
 
-	// declaration of odometry object
-	private Odometry swerveOdometry;
-	// variable representing current position
-	private static PointDir currentPosition;
+    // declaration of odometry object
+    private Odometry swerveOdometry;
+    // variable representing current position
+    private static PointDir currentPosition;
 
-	public Drive() {
-		loggerCategory = Category.DRIVE;
+    public Drive() {
+        loggerCategory = Category.DRIVE;
 
-		// create the drive motors
-		MotorController driveFR = RobotProvider.instance.getMotor(DRIVE_DRIVE_FRONT_RIGHT);
-		MotorController driveFL = RobotProvider.instance.getMotor(DRIVE_DRIVE_FRONT_LEFT);
-		MotorController driveBR = RobotProvider.instance.getMotor(DRIVE_DRIVE_BACK_RIGHT);
-		MotorController driveBL = RobotProvider.instance.getMotor(DRIVE_DRIVE_BACK_LEFT);
+        // create the drive motors
+        MotorController driveFR = RobotProvider.instance.getMotor(DRIVE_DRIVE_FRONT_RIGHT);
+        MotorController driveFL = RobotProvider.instance.getMotor(DRIVE_DRIVE_FRONT_LEFT);
+        MotorController driveBR = RobotProvider.instance.getMotor(DRIVE_DRIVE_BACK_RIGHT);
+        MotorController driveBL = RobotProvider.instance.getMotor(DRIVE_DRIVE_BACK_LEFT);
 
-		// create the steering motors
-		MotorController steerFR = RobotProvider.instance.getMotor(DRIVE_STEER_FRONT_RIGHT);
-		MotorController steerFL = RobotProvider.instance.getMotor(DRIVE_STEER_FRONT_LEFT);
-		MotorController steerBR = RobotProvider.instance.getMotor(DRIVE_STEER_BACK_RIGHT);
-		MotorController steerBL = RobotProvider.instance.getMotor(DRIVE_STEER_BACK_LEFT);
+        // create the steering motors
+        MotorController steerFR = RobotProvider.instance.getMotor(DRIVE_STEER_FRONT_RIGHT);
+        MotorController steerFL = RobotProvider.instance.getMotor(DRIVE_STEER_FRONT_LEFT);
+        MotorController steerBR = RobotProvider.instance.getMotor(DRIVE_STEER_BACK_RIGHT);
+        MotorController steerBL = RobotProvider.instance.getMotor(DRIVE_STEER_BACK_LEFT);
 
-		// create the encoders
-		CANCoder encoderFR = new CANCoder(2, SwerveDriveConstants.SWERVE_CANBUS);
-		CANCoder encoderFL = new CANCoder(4, SwerveDriveConstants.SWERVE_CANBUS);
-		CANCoder encoderBR = new CANCoder(3, SwerveDriveConstants.SWERVE_CANBUS);
-		CANCoder encoderBL = new CANCoder(1, SwerveDriveConstants.SWERVE_CANBUS);
+        // create the encoders
+        CANCoder encoderFR = new CANCoder(2, SwerveDriveConstants.SWERVE_CANBUS);
+        CANCoder encoderFL = new CANCoder(4, SwerveDriveConstants.SWERVE_CANBUS);
+        CANCoder encoderBR = new CANCoder(3, SwerveDriveConstants.SWERVE_CANBUS);
+        CANCoder encoderBL = new CANCoder(1, SwerveDriveConstants.SWERVE_CANBUS);
 
-		// initialize the swerve modules
-		swerveFR = new SwerveModule("FR", driveFR, steerFR, encoderFR);
-		swerveFL = new SwerveModule("FL", driveFL, steerFL, encoderFL);
-		swerveBR = new SwerveModule("BR", driveBR, steerBR, encoderBR);
-		swerveBL = new SwerveModule("BL", driveBL, steerBL, encoderBL);
+        // initialize the swerve modules
+        swerveFR = new SwerveModule("FR", driveFR, steerFR, encoderFR);
+        swerveFL = new SwerveModule("FL", driveFL, steerFL, encoderFL);
+        swerveBR = new SwerveModule("BR", driveBR, steerBR, encoderBR);
+        swerveBL = new SwerveModule("BL", driveBL, steerBL, encoderBL);
 
-		// Sets up odometry
-		currentPosition = new PointDir(0, 0, 0);
-		MotorController[] motorList = new MotorController[] { driveFR, driveFL, driveBL,
-				driveBR };
-		CANCoder[] encoderList = new CANCoder[] { encoderFR, encoderFL, encoderBL, encoderBR};
-		Point[] wheelPositions =
-				new Point[] {new Point(OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2, OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2),
-						new Point(OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2, -OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2),
-						new Point(-OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2, -OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2),
-						new Point(-OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2, OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2)};
-		log("MotorList Length: " + motorList.length);
-		log("CANCoderList Length: " + encoderList.length);
-		swerveOdometry = new Odometry(motorList, encoderList, wheelPositions, OdometryInputConstants.	WHEEL_CIRCUMFERENCE, OdometryInputConstants.GEAR_RATIO, OdometryInputConstants.ENCODER_TO_REVOLUTION_CONSTANT, OdometryInputConstants.RATE_LIMITER_TIME);
-	}
+        // Sets up odometry
+        currentPosition = new PointDir(0, 0, 0);
+        MotorController[] motorList = new MotorController[] {driveFR, driveFL, driveBL, driveBR};
+        CANCoder[] encoderList = new CANCoder[] {encoderFR, encoderFL, encoderBL, encoderBR};
+        Point[] wheelPositions =
+                new Point[] {
+                    new Point(
+                            OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2,
+                            OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2),
+                    new Point(
+                            OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2,
+                            -OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2),
+                    new Point(
+                            -OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2,
+                            -OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2),
+                    new Point(
+                            -OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2,
+                            OdometryInputConstants.DISTANCE_BETWEEN_WHEELS / 2)
+                };
+        log("MotorList Length: " + motorList.length);
+        log("CANCoderList Length: " + encoderList.length);
+        swerveOdometry =
+                new Odometry(
+                        motorList,
+                        encoderList,
+                        wheelPositions,
+                        OdometryInputConstants.WHEEL_CIRCUMFERENCE,
+                        OdometryInputConstants.GEAR_RATIO,
+                        OdometryInputConstants.ENCODER_TO_REVOLUTION_CONSTANT,
+                        OdometryInputConstants.RATE_LIMITER_TIME);
+    }
 
-	/** 
-	 * Maps parameters to robot oriented swerve movement
-	 * @param x the x value for the position joystick
-	 * @param y the y value for the position joystick
-	 * @param turn the turn value from the rotation joystick
-	 */
-	public void controlRobotOriented(double x, double y, double turn) {
-		checkContextOwnership();
+    /**
+     * Maps parameters to robot oriented swerve movement
+     * @param x the x value for the position joystick
+     * @param y the y value for the position joystick
+     * @param turn the turn value from the rotation joystick
+     */
+    public void controlRobotOriented(double x, double y, double turn) {
+        checkContextOwnership();
 
-		// Finds the vectors for turning and for translation of each module, and adds them
-		// Applies this for each module
-		swerveFL.driveAndSteer(new Vector2D(x, y).add(
-			turn, new Vector2D(SwerveDriveConstants.FL_Y, SwerveDriveConstants.FL_X).normalize()));
-		swerveFR.driveAndSteer(new Vector2D(x, y).add(
-			turn, new Vector2D(SwerveDriveConstants.FR_Y, SwerveDriveConstants.FR_X).normalize()));
-		swerveBR.driveAndSteer(new Vector2D(x, y).add(
-			turn, new Vector2D(SwerveDriveConstants.BR_Y, SwerveDriveConstants.BR_X).normalize()));
-		swerveBL.driveAndSteer(new Vector2D(x, y).add(
-			turn, new Vector2D(SwerveDriveConstants.BL_Y, SwerveDriveConstants.BL_X).normalize()));
-	}
+        // Finds the vectors for turning and for translation of each module, and adds them
+        // Applies this for each module
+        swerveFL.driveAndSteer(
+                new Vector2D(x, y)
+                        .add(
+                                turn,
+                                new Vector2D(SwerveDriveConstants.FL_Y, SwerveDriveConstants.FL_X)
+                                        .normalize()));
+        swerveFR.driveAndSteer(
+                new Vector2D(x, y)
+                        .add(
+                                turn,
+                                new Vector2D(SwerveDriveConstants.FR_Y, SwerveDriveConstants.FR_X)
+                                        .normalize()));
+        swerveBR.driveAndSteer(
+                new Vector2D(x, y)
+                        .add(
+                                turn,
+                                new Vector2D(SwerveDriveConstants.BR_Y, SwerveDriveConstants.BR_X)
+                                        .normalize()));
+        swerveBL.driveAndSteer(
+                new Vector2D(x, y)
+                        .add(
+                                turn,
+                                new Vector2D(SwerveDriveConstants.BL_Y, SwerveDriveConstants.BL_X)
+                                        .normalize()));
+    }
 
-	/**
-	 * Uses controlRobotOriented() to control the robot relative to the field
-	 * @param yawRad the robot gyro's current yaw value in radians
-	 * @param x the x value for the position joystick
-	 * @param y the y value for the position joystick
-	 * @param turn the turn value from the rotation joystick
-	 */
-	public void controlFieldOriented(double yawRad, double x, double y, double turn) {
-		checkContextOwnership();
+    /**
+     * Uses controlRobotOriented() to control the robot relative to the field
+     * @param yawRad the robot gyro's current yaw value in radians
+     * @param x the x value for the position joystick
+     * @param y the y value for the position joystick
+     * @param turn the turn value from the rotation joystick
+     */
+    public void controlFieldOriented(double yawRad, double x, double y, double turn) {
+        checkContextOwnership();
 
-		// Applies a rotational translation to controlRobotOriented
-		// Counteracts the forward direction changing when the robot turns
-		// TODO: change to inverse rotation matrix (rather than negative angle)
-		controlRobotOriented(Math.cos(-yawRad) * x - Math.sin(-yawRad) * y, Math.sin(-yawRad) * x + Math.cos(-yawRad) * y, turn);
-	}
+        // Applies a rotational translation to controlRobotOriented
+        // Counteracts the forward direction changing when the robot turns
+        // TODO: change to inverse rotation matrix (rather than negative angle)
+        controlRobotOriented(
+                Math.cos(-yawRad) * x - Math.sin(-yawRad) * y,
+                Math.sin(-yawRad) * x + Math.cos(-yawRad) * y,
+                turn);
+    }
 
-	/*
-	 * Stops each drive motor
-	 */
-	public void stopDrive() {
-		checkContextOwnership();
-		swerveFR.stopDrive();
-		swerveFL.stopDrive();
-		swerveBR.stopDrive();
-		swerveBL.stopDrive();
-	}
+    /*
+     * Stops each drive motor
+     */
+    public void stopDrive() {
+        checkContextOwnership();
+        swerveFR.stopDrive();
+        swerveFL.stopDrive();
+        swerveBR.stopDrive();
+        swerveBL.stopDrive();
+    }
 
-	/*
-	 * Turns wheels in a cross formation to prevent robot from moving
-	 */
-	public void setCross() {
-		checkContextOwnership();
+    /*
+     * Turns wheels in a cross formation to prevent robot from moving
+     */
+    public void setCross() {
+        checkContextOwnership();
 
-		swerveFL.steer(new Vector2D(SwerveDriveConstants.FL_Y, -SwerveDriveConstants.FL_X));
-		swerveFR.steer(new Vector2D(SwerveDriveConstants.FR_Y, -SwerveDriveConstants.FR_X));
-		swerveBL.steer(new Vector2D(SwerveDriveConstants.BL_Y, -SwerveDriveConstants.BL_X));
-		swerveBR.steer(new Vector2D(SwerveDriveConstants.BR_Y, -SwerveDriveConstants.BR_X));
-	}
+        swerveFL.steer(new Vector2D(SwerveDriveConstants.FL_Y, -SwerveDriveConstants.FL_X));
+        swerveFR.steer(new Vector2D(SwerveDriveConstants.FR_Y, -SwerveDriveConstants.FR_X));
+        swerveBL.steer(new Vector2D(SwerveDriveConstants.BL_Y, -SwerveDriveConstants.BL_X));
+        swerveBR.steer(new Vector2D(SwerveDriveConstants.BR_Y, -SwerveDriveConstants.BR_X));
+    }
 
-	// TODO: rework odometry so it doesn't have to go through drive
-	// TODO: figure out why odometry x and y are swapped
-	public PointDir getCurrentPosition() {
-		return currentPosition;
-	}
+    // TODO: rework odometry so it doesn't have to go through drive
+    // TODO: figure out why odometry x and y are swapped
+    public PointDir getCurrentPosition() {
+        return currentPosition;
+    }
 
-	public void setCurrentPosition(Point P) {
-		swerveOdometry.setCurrentPosition(P);
-	}
+    public void setCurrentPosition(Point P) {
+        swerveOdometry.setCurrentPosition(P);
+    }
 
-	public void resetCurrentPosition() {
-		swerveOdometry.setCurrentPosition(new Point(0, 0));
-	}
+    public void resetCurrentPosition() {
+        swerveOdometry.setCurrentPosition(new Point(0, 0));
+    }
 
-	// Odometry
-	@Override
-	public void run() {
-		currentPosition = swerveOdometry.run();
-		log(currentPosition.toString());
-		SmartDashboard.putString("position", currentPosition.toString());
-	}
+    // Odometry
+    @Override
+    public void run() {
+        currentPosition = swerveOdometry.run();
+        log(currentPosition.toString());
+        SmartDashboard.putString("position", currentPosition.toString());
+    }
 }

--- a/src/main/java/com/team766/robot/mechanisms/SwerveModule.java
+++ b/src/main/java/com/team766/robot/mechanisms/SwerveModule.java
@@ -1,90 +1,105 @@
 package com.team766.robot.mechanisms;
 
-import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
 import com.ctre.phoenix.sensors.CANCoder;
 import com.team766.hal.MotorController;
 import com.team766.hal.MotorController.ControlMode;
 import com.team766.robot.constants.SwerveDriveConstants;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
 
 /**
- * Encapsulates the motors and encoders used for each physical swerve module and 
+ * Encapsulates the motors and encoders used for each physical swerve module and
  * provides driving and steering controls for each module.
  */
 public class SwerveModule {
-	private final String modulePlacement;
-	private final MotorController drive;
-	private final MotorController steer;
-	private final CANCoder encoder;
-	private final double offset;
+    private final String modulePlacement;
+    private final MotorController drive;
+    private final MotorController steer;
+    private final CANCoder encoder;
+    private final double offset;
 
-	/*
-	 * Factor that converts between motor units and degrees
-	 * Multiply to convert from degrees to motor units
-	 * Divide to convert from motor units to degrees
-	 */
-	private static final double ENCODER_CONVERSION_FACTOR = (150.0 / 7.0) /*steering gear ratio*/ * (2048.0 / 360.0) /*encoder units to degrees*/;
+    /*
+     * Factor that converts between motor units and degrees
+     * Multiply to convert from degrees to motor units
+     * Divide to convert from motor units to degrees
+     */
+    private static final double ENCODER_CONVERSION_FACTOR =
+            (150.0 / 7.0) /*steering gear ratio*/ * (2048.0 / 360.0) /*encoder units to degrees*/;
 
-	/**
-	 * Creates a new SwerveModule.
-	 * 
-	 * @param modulePlacement String description of the placement for this module, eg "FL".
-	 * @param drive Drive MotorController for this module.
-	 * @param steer Steer MotorController for this module.
-	 * @param encoder CANCoder for this module.
-	 */
-	public SwerveModule(String modulePlacement, MotorController drive, MotorController steer, CANCoder encoder) {
-		this.modulePlacement = modulePlacement;
-		this.drive = drive;
-		this.steer = steer;
-		this.encoder = encoder;
-		this.offset = computeEncoderOffset();
+    /**
+     * Creates a new SwerveModule.
+     *
+     * @param modulePlacement String description of the placement for this module, eg "FL".
+     * @param drive Drive MotorController for this module.
+     * @param steer Steer MotorController for this module.
+     * @param encoder CANCoder for this module.
+     */
+    public SwerveModule(
+            String modulePlacement,
+            MotorController drive,
+            MotorController steer,
+            CANCoder encoder) {
+        this.modulePlacement = modulePlacement;
+        this.drive = drive;
+        this.steer = steer;
+        this.encoder = encoder;
+        this.offset = computeEncoderOffset();
 
-		// Current limit for motors to avoid breaker problems 
-		drive.setCurrentLimit(SwerveDriveConstants.DRIVE_MOTOR_CURRENT_LIMIT);
-		steer.setCurrentLimit(SwerveDriveConstants.STEER_MOTOR_CURRENT_LIMIT);
-	}
+        // Current limit for motors to avoid breaker problems
+        drive.setCurrentLimit(SwerveDriveConstants.DRIVE_MOTOR_CURRENT_LIMIT);
+        steer.setCurrentLimit(SwerveDriveConstants.STEER_MOTOR_CURRENT_LIMIT);
+    }
 
-	private double computeEncoderOffset() {
-		return (steer.getSensorPosition() / ENCODER_CONVERSION_FACTOR) % 360 - encoder.getAbsolutePosition();
-	}
+    private double computeEncoderOffset() {
+        return (steer.getSensorPosition() / ENCODER_CONVERSION_FACTOR) % 360
+                - encoder.getAbsolutePosition();
+    }
 
-	/**
-	 * Controls just the steer for this module.
-	 * Can be used to turn the wheels without moving
-	 * @param vector the vector specifying the module's motion
-	 */
-	public void steer(Vector2D vector) {
-		// Calculates the angle of the vector from -180° to 180°
-		final double vectorTheta = Math.toDegrees(Math.atan2(vector.getY(), vector.getX()));
+    /**
+     * Controls just the steer for this module.
+     * Can be used to turn the wheels without moving
+     * @param vector the vector specifying the module's motion
+     */
+    public void steer(Vector2D vector) {
+        // Calculates the angle of the vector from -180° to 180°
+        final double vectorTheta = Math.toDegrees(Math.atan2(vector.getY(), vector.getX()));
 
-		// Add 360 * number of full rotations to vectorTheta, then add offset
-		final double angleDegrees = vectorTheta + 360*(Math.round((steer.getSensorPosition()/ENCODER_CONVERSION_FACTOR - offset - vectorTheta)/360)) + offset;
+        // Add 360 * number of full rotations to vectorTheta, then add offset
+        final double angleDegrees =
+                vectorTheta
+                        + 360
+                                * (Math.round(
+                                        (steer.getSensorPosition() / ENCODER_CONVERSION_FACTOR
+                                                        - offset
+                                                        - vectorTheta)
+                                                / 360))
+                        + offset;
 
-		// Sets the degree of the steer wheel
-		// Needs to multiply by ENCODER_CONVERSION_FACTOR to translate into a unit the motor understands
-		steer.set(ControlMode.Position, ENCODER_CONVERSION_FACTOR*angleDegrees);
+        // Sets the degree of the steer wheel
+        // Needs to multiply by ENCODER_CONVERSION_FACTOR to translate into a unit the motor
+        // understands
+        steer.set(ControlMode.Position, ENCODER_CONVERSION_FACTOR * angleDegrees);
 
-		SmartDashboard.putNumber("[" + modulePlacement + "]" + "Angle", angleDegrees);
-	}
+        SmartDashboard.putNumber("[" + modulePlacement + "]" + "Angle", angleDegrees);
+    }
 
-	/**
-	 * Controls both steer and power (based on the target vector) for this module.
-	 * @param vector the vector specifying the module's motion
-	 */
-	public void driveAndSteer(Vector2D vector) {
-		// apply the steer
-		steer(vector);
+    /**
+     * Controls both steer and power (based on the target vector) for this module.
+     * @param vector the vector specifying the module's motion
+     */
+    public void driveAndSteer(Vector2D vector) {
+        // apply the steer
+        steer(vector);
 
-		// sets the power to the magnitude of the vector
-		// TODO: does this need to be clamped to a specific range, eg btn -1 and 1?
-		drive.set(vector.getNorm());
-	}
+        // sets the power to the magnitude of the vector
+        // TODO: does this need to be clamped to a specific range, eg btn -1 and 1?
+        drive.set(vector.getNorm());
+    }
 
-	/**
-	 * Stops the drive motor for this module.
-	 */
-	public void stopDrive() {
-		drive.stopMotor();
-	}
+    /**
+     * Stops the drive motor for this module.
+     */
+    public void stopDrive() {
+        drive.stopMotor();
+    }
 }


### PR DESCRIPTION
## Description

refactors swerve code in Drive by separating out each drive+steer+encoder in a physical swerve module to be encapsulated in a new SwerveModule class.  this both tidies up Drive and more significantly helps us prepare for AdvantageKit integration, so we can use AdvantageScope to plot and analyze our [swerve](https://github.com/Mechanical-Advantage/AdvantageScope/blob/main/docs/tabs/SWERVE.md) behavior.

## How Has This Been Tested?

this will need to be tested on Gatorade, once programming has access to Gatorade again.